### PR TITLE
Don't depend on assertj-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.2.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
assertj-core is only used in test code, so declare the dependency with test scope.